### PR TITLE
update to the commit message pattern

### DIFF
--- a/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationBusiness.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationBusiness.java
@@ -232,22 +232,26 @@ public class ScmSyncConfigurationBusiness {
 		}
 	}
 	
-	private static String createCommitMessage(ScmContext context, String messagePrefix, User user, String comment){
-		StringBuilder commitMessage = new StringBuilder();
-		commitMessage.append(messagePrefix);
+	private static String createCommitMessage(ScmContext context, String technicalMessage, User user, String comment){
+		StringBuilder messageBuilder = new StringBuilder();
+		messageBuilder.append(technicalMessage);
 		if(user != null){
-			commitMessage.append(" by ").append(user.getId());
+			messageBuilder.append(" by ").append(user.getId());
 		}
 		if(comment != null){
-			commitMessage.append(" with following comment : ").append(comment);
+			messageBuilder.append(" with following comment : ").append(comment);
 		}
-		String message = commitMessage.toString();
+		String message = messageBuilder.toString();
 
         if(context.getCommitMessagePattern() == null || "".equals(context.getCommitMessagePattern())){
             return message;
         } else {
             String returnString = context.getCommitMessagePattern().replaceAll("\\[message\\]", message);
-            returnString = context.getCommitMessagePattern().replaceAll("\\[comment\\]", comment);
+            returnString = returnString.replaceAll("\\[commitMessage\\]", comment);
+            returnString = returnString.replaceAll("\\[technicalMessage\\]", technicalMessage);
+            if(user != null) {
+                returnString = returnString.replaceAll("\\[user\\]", user.getId());
+            }
             return returnString;
         }
 	}

--- a/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationBusiness.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationBusiness.java
@@ -246,7 +246,9 @@ public class ScmSyncConfigurationBusiness {
         if(context.getCommitMessagePattern() == null || "".equals(context.getCommitMessagePattern())){
             return message;
         } else {
-            return context.getCommitMessagePattern().replaceAll("\\[message\\]", message);
+            String returnString = context.getCommitMessagePattern().replaceAll("\\[message\\]", message);
+            returnString = context.getCommitMessagePattern().replaceAll("\\[comment\\]", comment);
+            return returnString;
         }
 	}
 	

--- a/src/main/webapp/help/commitMessagePattern-help.html
+++ b/src/main/webapp/help/commitMessagePattern-help.html
@@ -5,8 +5,17 @@
     You can use following "special" strings in the pattern :
     <ul>
         <li>`[message]` : Will be replaced by the generated commit message</li>
+        <li>`[comment]` : Will replace the commit message with your comment as is (i.e not the generated parts of the message)</li>
     </ul>
     <br/><br/>
-    For instance, defining a commit message pattern of "ISSUE-1234: [message]" will make following commit message :<br/>
+    Example for using `[message]`:
+    Writing a commit message of "Synchronization init" and defining a commit message pattern of "ISSUE-1234: [message]" <br/>
+    will make following commit message :<br/>
     ISSUE-1234: Modification on file with following comment : Synchronization init
+    <br/>
+    Example for using `[comment]`:
+    Making a commit comment of "Synchronization init" and defining a commit message pattern of "ISSUE-1234: [comment]" <br/> 
+    will make following commit message :<br/>
+    ISSUE-1234: Synchronization init
+    
 </div>

--- a/src/main/webapp/help/commitMessagePattern-help.html
+++ b/src/main/webapp/help/commitMessagePattern-help.html
@@ -5,17 +5,21 @@
     You can use following "special" strings in the pattern :
     <ul>
         <li>`[message]` : Will be replaced by the generated commit message</li>
-        <li>`[comment]` : Will replace the commit message with your comment as is (i.e not the generated parts of the message)</li>
+        <li>`[commitMessage]` : Will be replaced by the the comment you specified</li>
+        <li>`[technicalMessage] : Will be replaced by the the technical details of the current commit`</li>
+        <li>`[user] : Will be replaced by your Jenkins username`</li>
     </ul>
-    <br/><br/>
+    <br/>
+    <br/>
     Example for using `[message]`:
     Writing a commit message of "Synchronization init" and defining a commit message pattern of "ISSUE-1234: [message]" <br/>
     will make following commit message :<br/>
     ISSUE-1234: Modification on file with following comment : Synchronization init
     <br/>
-    Example for using `[comment]`:
-    Making a commit comment of "Synchronization init" and defining a commit message pattern of "ISSUE-1234: [comment]" <br/> 
-    will make following commit message :<br/>
-    ISSUE-1234: Synchronization init
+    <br/>
+    If you need finer grained control the message above is equivalent to using a message pattern of:<br/>
+    ISSUE-1234 [technicalMessage] by [user] with following comment: [commitMessage]
+    <br/>
+    
     
 </div>


### PR DESCRIPTION
At our company we have a scm pre-commit hook that expects commit messages in the following pattern:
bug# - commit message

With the current implementation there is no way to have only your commit message used without extra text. 
e.g: "Modification on file with following comment : MY COMMENT" instead of simply "MY COMMENT"

I have added a `[comment]` pattern, that will get replaced with the exact text from your comment.  