### PR TITLE
[JENKINS-14893] reduce memory consumption / OOME

### DIFF
--- a/src/main/resources/hudson/plugins/scm_sync_configuration/extensions/ScmSyncConfigurationPageDecorator/footer.jelly
+++ b/src/main/resources/hudson/plugins/scm_sync_configuration/extensions/ScmSyncConfigurationPageDecorator/footer.jelly
@@ -43,18 +43,18 @@
     
 </j:if>
 
-<j:set var="success" value="${it.getScmSyncConfigPlugin().getScmSyncConfigurationStatusManager().getLastSuccess()}"/>
-<j:if test="${success != null}">
-    <j:set var="icon" value="health-80plus" />
-    <j:set var="msg" value="Last operation @ ${success}" />
-</j:if>
-<j:set var="fail" value="${it.getScmSyncConfigPlugin().getScmSyncConfigurationStatusManager().getLastFail()}"/>
-<j:if test="${fail != null}">
-    <j:set var="icon" value="error" />
-    <j:set var="msg" value="&lt;br/&gt;${fail}&lt;br/&gt;To remove this message, please remove JENKINS_HOME/scm-sync-configuration.*.log files" />
-</j:if>
-
 <j:if test="${it.getScmSyncConfigPlugin().displayStatus}">
+	<j:set var="success" value="${it.getScmSyncConfigPlugin().getScmSyncConfigurationStatusManager().getLastSuccess()}"/>
+	<j:if test="${success != null}">
+	    <j:set var="icon" value="health-80plus" />
+	    <j:set var="msg" value="Last operation @ ${success}" />
+	</j:if>
+	<j:set var="fail" value="${it.getScmSyncConfigPlugin().getScmSyncConfigurationStatusManager().getLastFail()}"/>
+	<j:if test="${fail != null}">
+	    <j:set var="icon" value="error" />
+	    <j:set var="msg" value="&lt;br/&gt;${fail}&lt;br/&gt;To remove this message, please remove JENKINS_HOME/scm-sync-configuration.*.log files" />
+	</j:if>
+
     <table width="100%">
         <tr><td id="footer">
             <span style="color:gray">SCM Sync status : <img src="${imagesURL}/16x16/${icon}.png" alt="" height="16" width="16"/>


### PR DESCRIPTION
Hi,

this is rather simple: Instead of reading the logs always, the change checks first if the user enabled "displayStatus".
Solved the memory consumption issues we had on our Jenkins instance.

Martin
