### PR TITLE
Update maven-scm plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /work
 /work-backup
 *.iml
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,14 @@
 			</execution>
 			</executions>
 		</plugin>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-compiler-plugin</artifactId>
+			<configuration>
+				<source>1.6</source>
+				<target>1.6</target>
+			</configuration>
+		</plugin>
 	</plugins>
   </build>
 
@@ -125,7 +133,7 @@
   	<dependency>
       <groupId>org.apache.maven.scm</groupId>
       <artifactId>maven-scm-manager-plexus</artifactId>
-      <version>1.6</version>
+      <version>1.8.1</version>
       <!-- 
       <exclusions>
       	<exclusion>
@@ -158,9 +166,8 @@
     <dependency>
       <groupId>org.apache.maven.scm</groupId>
       <artifactId>maven-scm-provider-gitexe</artifactId>
-      <version>1.6</version>
+      <version>1.8.1</version>
     </dependency>
-    
     
     <!-- TEST DEPENDENCIES -->
     <!-- powermock to mock static methods.. especially Hudson.getInstance() -->

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -37,5 +37,11 @@ under the License.
       <implementation>org.apache.maven.scm.provider.svn.svnjava.SvnJavaScmProvider</implementation>
       <!-- <implementation>org.apache.maven.scm.provider.svn.svnexe.SvnExeScmProvider</implementation> -->
     </component>
+    
+    <component>
+      <role>org.apache.maven.scm.provider.ScmProvider</role>
+      <role-hint>git</role-hint>
+      <implementation>org.apache.maven.scm.provider.git.gitexe.GitExeScmProvider</implementation>
+    </component>
   </components>
 </component-set>


### PR DESCRIPTION
1. Updates maven-scm-provider-gitexe and maven-scm-manager-plexus to 1.8.1
2. Define scm provider for git as plexus component
