### PR TITLE
JENKINS-17545 : Alternate fix (original fix broken on windows)

### DIFF
--- a/src/main/java/hudson/plugins/scm_sync_configuration/strategies/model/PatternsEntityMatcher.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/strategies/model/PatternsEntityMatcher.java
@@ -4,6 +4,7 @@ import hudson.model.Hudson;
 import hudson.model.Saveable;
 import hudson.plugins.scm_sync_configuration.JenkinsFilesHelper;
 import org.apache.tools.ant.DirectoryScanner;
+import org.springframework.util.AntPathMatcher;
 
 import java.io.File;
 import java.util.Arrays;
@@ -22,8 +23,9 @@ public class PatternsEntityMatcher implements ConfigurationEntityMatcher {
 			return false;
 		}
 		String filePathRelativeToHudsonRoot = JenkinsFilesHelper.buildPathRelativeToHudsonRoot(file);
-		for(String matchingFile : matchingFilesFrom(Hudson.getInstance().getRootDir())) {
-            if(matchingFile.equals(filePathRelativeToHudsonRoot)){
+		AntPathMatcher matcher = new AntPathMatcher();
+		for (String pattern : includesPatterns) {
+            if (matcher.match(pattern, filePathRelativeToHudsonRoot)) {
                 return true;
             }
 		}


### PR DESCRIPTION
Re-scanning the complete list of watched files to check for a match is not efficient,
and doesn't work on windows : the returned names use '\' as separator, so they
never match with the looked-for file, which has canonical '/' separator.
org.springframework.util.AntPathMatcher seems to do the job.
