### PR TITLE
Support folders (cloudbees folders plugin)

### DIFF
--- a/src/main/java/hudson/plugins/scm_sync_configuration/strategies/impl/JobConfigScmSyncStrategy.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/strategies/impl/JobConfigScmSyncStrategy.java
@@ -4,6 +4,7 @@ import hudson.XmlFile;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Saveable;
+import hudson.model.TopLevelItem;
 import hudson.plugins.scm_sync_configuration.model.MessageWeight;
 import hudson.plugins.scm_sync_configuration.model.WeightedMessage;
 import hudson.plugins.scm_sync_configuration.strategies.AbstractScmSyncStrategy;
@@ -18,15 +19,15 @@ public class JobConfigScmSyncStrategy extends AbstractScmSyncStrategy {
 
     // Don't miss to take into account view urls since we can configure a job through a view !
 	private static final List<PageMatcher> PAGE_MATCHERS = new ArrayList<PageMatcher>(){ {
-        add(new PageMatcher("^(.*view/[^/]+/)?job/[^/]+/configure$", "form[name='config']"));
+        add(new PageMatcher("^(.*view/[^/]+/)?(/job/[^/])*/job/[^/]+/configure$", "form[name='config']"));
     } };
     // Only saving config.xml file located in job directory
     // Some plugins (like maven release plugin) could add their own configuration files in the job directory that we don't want to synchronize
     // ... at least in the current strategy !
 	private static final String [] PATTERNS = new String[] {
-        "jobs/*/config.xml"
+        "**/jobs/*/config.xml"
 	};
-	private static final ConfigurationEntityMatcher CONFIG_ENTITY_MANAGER = new ClassAndFileConfigurationEntityMatcher(Job.class, PATTERNS);
+	private static final ConfigurationEntityMatcher CONFIG_ENTITY_MANAGER = new ClassAndFileConfigurationEntityMatcher(TopLevelItem.class, PATTERNS);
 	
 	public JobConfigScmSyncStrategy(){
 		super(CONFIG_ENTITY_MANAGER, PAGE_MATCHERS);
@@ -35,7 +36,7 @@ public class JobConfigScmSyncStrategy extends AbstractScmSyncStrategy {
     public CommitMessageFactory getCommitMessageFactory(){
         return new CommitMessageFactory(){
             public WeightedMessage getMessageWhenSaveableUpdated(Saveable s, XmlFile file) {
-                return new WeightedMessage("Job ["+((Job)s).getName()+"] configuration updated",
+                return new WeightedMessage("Job ["+((Item)s).getName()+"] configuration updated",
                         // Job config update message should be considered as "important", especially
                         // more important than the plugin descriptors Saveable updates
                         MessageWeight.IMPORTANT);

--- a/src/test/java/hudson/plugins/scm_sync_configuration/repository/HudsonExtensionsTest.java
+++ b/src/test/java/hudson/plugins/scm_sync_configuration/repository/HudsonExtensionsTest.java
@@ -4,6 +4,7 @@ import hudson.XmlFile;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Saveable;
+import hudson.model.TopLevelItem;
 import hudson.plugins.scm_sync_configuration.SCMManipulator;
 import hudson.plugins.scm_sync_configuration.ScmSyncConfigurationPlugin;
 import hudson.plugins.scm_sync_configuration.extensions.ScmSyncConfigurationItemListener;
@@ -60,7 +61,7 @@ public abstract class HudsonExtensionsTest extends ScmSyncConfigurationPluginBas
 		sscBusiness.synchronizeAllConfigs(ScmSyncConfigurationPlugin.AVAILABLE_STRATEGIES);
 		
 		// Renaming fakeJob to newFakeJob
-		Item mockedItem = Mockito.mock(Job.class);
+		Item mockedItem = Mockito.mock(TopLevelItem.class);
 		File mockedItemRootDir = new File(getCurrentHudsonRootDirectory() + "/jobs/newFakeJob/" );
 		when(mockedItem.getRootDir()).thenReturn(mockedItemRootDir);
         when(mockedItem.getName()).thenReturn("newFakeJob");
@@ -90,7 +91,7 @@ public abstract class HudsonExtensionsTest extends ScmSyncConfigurationPluginBas
 		FileUtils.copyFile(new ClassPathResource("expected-scm-hierarchies/HudsonExtensionsTest.shouldJobAddBeCorrectlyImpactedOnSCM/jobs/newFakeJob/config.xml").getFile(), configFile);
 		
 		// Creating fake new job
-		Item mockedItem = Mockito.mock(Job.class);
+		Item mockedItem = Mockito.mock(TopLevelItem.class);
 		when(mockedItem.getRootDir()).thenReturn(jobDirectory);
 		
 		sscItemListener.onCreated(mockedItem);
@@ -116,7 +117,7 @@ public abstract class HudsonExtensionsTest extends ScmSyncConfigurationPluginBas
 		File configFile = new File(jobDirectory.getAbsolutePath() + File.separator + "config.xml");
 		
 		// Creating fake new job
-		Item mockedItem = Mockito.mock(Job.class);
+		Item mockedItem = Mockito.mock(TopLevelItem.class);
 		when(mockedItem.getRootDir()).thenReturn(jobDirectory);
 		
 		sscItemListener.onCreated(mockedItem);
@@ -205,7 +206,7 @@ public abstract class HudsonExtensionsTest extends ScmSyncConfigurationPluginBas
 		sscBusiness.synchronizeAllConfigs(ScmSyncConfigurationPlugin.AVAILABLE_STRATEGIES);
 		
 		// Deleting fakeJob
-		Item mockedItem = Mockito.mock(Job.class);
+		Item mockedItem = Mockito.mock(TopLevelItem.class);
 		File mockedItemRootDir = new File(getCurrentHudsonRootDirectory() + "/jobs/fakeJob/" );
 		when(mockedItem.getRootDir()).thenReturn(mockedItemRootDir);
 		
@@ -228,7 +229,7 @@ public abstract class HudsonExtensionsTest extends ScmSyncConfigurationPluginBas
 		sscBusiness.synchronizeAllConfigs(ScmSyncConfigurationPlugin.AVAILABLE_STRATEGIES);
 		
 		// Deleting fakeJob
-		Item mockedItem = Mockito.mock(Job.class);
+		Item mockedItem = Mockito.mock(TopLevelItem.class);
 		File mockedItemRootDir = new File(getCurrentHudsonRootDirectory() + "/jobs/fakeJob/" );
 		when(mockedItem.getRootDir()).thenReturn(mockedItemRootDir);
 		
@@ -367,7 +368,7 @@ public abstract class HudsonExtensionsTest extends ScmSyncConfigurationPluginBas
 		assertStrategy(null, Mockito.mock(Job.class), "toto" + File.separator + "config.xml");
 		assertStrategy(null, Mockito.mock(Job.class), "jobs" + File.separator + "config.xml");
 		assertStrategy(null, Mockito.mock(Saveable.class), "jobs" + File.separator + "myJob" + File.separator + "config.xml");
-		assertStrategy(JobConfigScmSyncStrategy.class, Mockito.mock(Job.class), "jobs" + File.separator + "myJob" + File.separator + "config.xml");
+		assertStrategy(JobConfigScmSyncStrategy.class, Mockito.mock(TopLevelItem.class), "jobs" + File.separator + "myJob" + File.separator + "config.xml");
 		assertStrategy(null, Mockito.mock(Job.class), "jobs" + File.separator + "myJob" + File.separator + "config2.xml");
 	}
 


### PR DESCRIPTION
Consider nested level of '/jobs/*' as candidate files for sync
don't assume all items are actual Jobs, but TopLevelItems
