### PR TITLE
fix for JENKINS-23036 : using rootURL (not rootUrl) for some jelly files...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /work
 /work-backup
 *.iml
+.idea

--- a/src/main/resources/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin/config.jelly
+++ b/src/main/resources/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin/config.jelly
@@ -49,7 +49,7 @@
         </f:repeatable>
     </f:entry>
     <f:entry title="${%Reload config from SCM}" help="${rootUrl}/plugin/scm-sync-configuration/help/reloadScmConfig-help.html">
-    	<a href="${rootUrl}/plugin/scm-sync-configuration/reloadAllFilesFromScm" onClick="return confirm('${%WARNING : the Jenkins config will be reloaded from SCM}.\n${%Only file modifications are handled}. ${%File added or removed will not be handled} !\n\n${%Continue} ?')">${%Reload}</a>
+    	<a href="${rootURL}/plugin/scm-sync-configuration/reloadAllFilesFromScm" onClick="return confirm('${%WARNING : the Jenkins config will be reloaded from SCM}.\n${%Only file modifications are handled}. ${%File added or removed will not be handled} !\n\n${%Continue} ?')">${%Reload}</a>
     </f:entry>
   </f:section>
   

--- a/src/main/resources/hudson/plugins/scm_sync_configuration/reload.jelly
+++ b/src/main/resources/hudson/plugins/scm_sync_configuration/reload.jelly
@@ -13,7 +13,7 @@
         </j:forEach>
         </ul>
       </p>
-      <h3>Please reload Jenkins config from disk by clicking <a href="${rootUrl}/reload">here</a></h3>
+      <h3>Please reload Jenkins config from disk by clicking <a href="${rootURL}/reload">here</a></h3>
       
     </l:main-panel>
  </l:layout>


### PR DESCRIPTION
This pull request changes the rootUrl variable to rootURL, as suggested by:
https://wiki.jenkins-ci.org/display/JENKINS/Basic+guide+to+Jelly+usage+in+Jenkins.

The bug inexplicably only affects HTML anchors, and not Help attributes. JEXL syntax indicates variables are case sensitive, which provides some insight into why this predefined object did not work for Jenkins instances with context paths.

Unfortunately we could not write tests for this, as there is no (easily found) documentation on how to test rendered Jenkins jelly files. We were able to manually test and validate the fix on older and newer versions of Jenkins, as well as Jenkins instances that do and do not contain context paths.
