### PR TITLE
Avoid unnecessary exceptions on Jenkins log

### DIFF
--- a/src/main/java/hudson/plugins/scm_sync_configuration/strategies/model/PatternsEntityMatcher.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/strategies/model/PatternsEntityMatcher.java
@@ -25,6 +25,7 @@ public class PatternsEntityMatcher implements ConfigurationEntityMatcher {
             
             // in case **/jobs/ directory is a link to a mounted volume so nextBuildNumber stays in sync with buildHistory and symlinks
             // such cases are usual when running Jenkins in Docker as a Phoenix Docker Container
+            // adding this check avoids unnecessary Exceptions on Jenkins logs
             if (file.getAbsolutePath() == null ||
                 !file.getAbsolutePath().startsWith(Hudson.getInstance().getRootDir().getAbsolutePath())) {
               	return false;
@@ -36,7 +37,6 @@ public class PatternsEntityMatcher implements ConfigurationEntityMatcher {
               if(matcher.match(pattern, filePathRelativeToHudsonRoot)){
                 return true;
               }
-            	
             }
             return false;
 	}

--- a/src/main/java/hudson/plugins/scm_sync_configuration/strategies/model/PatternsEntityMatcher.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/strategies/model/PatternsEntityMatcher.java
@@ -22,12 +22,12 @@ public class PatternsEntityMatcher implements ConfigurationEntityMatcher {
 	    if (file == null) {
 	    	return false;
             }
-	    
-	    // in case **/jobs/ directory is a link to a mounted volume so nextBuildNumber stays in sync with buildHistory and symlinks
-	    // such cases are usual when running Jenkins in Docker as a Phoenix Docker Container
-	    if (file.getAbsolutePath() == null ||
-	        !file.getAbsolutePath().startsWith(Hudson.getInstance().getRootDir().getAbsolutePath())) {
-	    	return false;
+            
+            // in case **/jobs/ directory is a link to a mounted volume so nextBuildNumber stays in sync with buildHistory and symlinks
+            // such cases are usual when running Jenkins in Docker as a Phoenix Docker Container
+            if (file.getAbsolutePath() == null ||
+                !file.getAbsolutePath().startsWith(Hudson.getInstance().getRootDir().getAbsolutePath())) {
+              	return false;
             }
             
             String filePathRelativeToHudsonRoot = JenkinsFilesHelper.buildPathRelativeToHudsonRoot(file);

--- a/src/main/java/hudson/plugins/scm_sync_configuration/strategies/model/PatternsEntityMatcher.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/strategies/model/PatternsEntityMatcher.java
@@ -19,17 +19,26 @@ public class PatternsEntityMatcher implements ConfigurationEntityMatcher {
     }
 
 	public boolean matches(Saveable saveable, File file) {
-		if (file == null) {
-			return false;
-		}
-		String filePathRelativeToHudsonRoot = JenkinsFilesHelper.buildPathRelativeToHudsonRoot(file);
-        AntPathMatcher matcher = new AntPathMatcher();
-        for(String pattern : includesPatterns) {
-            if(matcher.match(pattern, filePathRelativeToHudsonRoot)){
-                return true;
+	    if (file == null) {
+	    	return false;
             }
-		}
-		return false;
+	    
+	    // in case **/jobs/ directory is a link to a mounted volume so nextBuildNumber stays in sync with buildHistory and symlinks
+	    // such cases are usual when running Jenkins in Docker as a Phoenix Docker Container
+	    if (file.getAbsolutePath() == null ||
+	        !file.getAbsolutePath().startsWith(Hudson.getInstance().getRootDir().getAbsolutePath())) {
+	    	return false;
+            }
+            
+            String filePathRelativeToHudsonRoot = JenkinsFilesHelper.buildPathRelativeToHudsonRoot(file);
+            AntPathMatcher matcher = new AntPathMatcher();
+            for(String pattern : includesPatterns) {
+              if(matcher.match(pattern, filePathRelativeToHudsonRoot)){
+                return true;
+              }
+            	
+            }
+            return false;
 	}
 
     public List<String> getIncludes(){


### PR DESCRIPTION

in case **/jobs/ directory is a link to a mounted volume so nextBuildNumber stays in sync with buildHistory and symlinks
such cases are usual when running Jenkins in Docker as a Phoenix Docker Container

* [x] adding this check avoids unnecessary Exceptions on Jenkins logs