### PR TITLE
Public method for UI-less reload in e. g. Groovy scripts

### DIFF
--- a/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin.java
@@ -262,6 +262,16 @@ public class ScmSyncConfigurationPlugin extends Plugin{
             }}));
     }
 
+    // public method for UI-less reload in e. g. Groovy scripts
+    public void reloadAllFilesFromScm() throws ServletException, IOException {
+        try {
+            filesModifiedByLastReload = business.reloadAllFilesFromScm();
+        }
+        catch(ScmException e) {
+            throw new ServletException("Unable to reload SCM " + scm.getTitle() + ":" + getScmUrl(), e);
+        }
+    }
+
     public void doReloadAllFilesFromScm(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
         try {
             filesModifiedByLastReload = business.reloadAllFilesFromScm();


### PR DESCRIPTION
Hey, I've ran into a problem recently where I had to reload the config files automatically in a Groovy script with the Jenkins CLI. In our case I had to expose the business variable with reflection, this would be definitely a cleaner solution.