### PR TITLE
JENKINS-32124: attempt to fix startup failure

### DIFF
--- a/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin.java
@@ -154,7 +154,6 @@ public class ScmSyncConfigurationPlugin extends Plugin{
         // because, for some unknown reasons, we reach plexus bootstraping exceptions when
         // calling Embedder.start() when everything is loaded (very strange...)
         SCMManagerFactory.getInstance().start();
-        initialInit();
     }
 
     public void loadData(ScmSyncConfigurationPOJO pojo){
@@ -164,14 +163,6 @@ public class ScmSyncConfigurationPlugin extends Plugin{
         this.displayStatus = pojo.isDisplayStatus();
         this.commitMessagePattern = pojo.getCommitMessagePattern();
         this.manualSynchronizationIncludes = pojo.getManualSynchronizationIncludes();
-    }
-
-    protected void initialInit() throws Exception {
-        // We need to init() here in addition to ScmSyncConfigurationItemListener.onLoaded() to ensure that we do
-        // indeed create the SCM work directory when we are loaded. Otherwise, the plugin can be installed but
-        // then fails to operate until the next time Jenkins is restarted. Using postInitialize() for this might
-        // be too late if the plugin is copied to the plugin directory and then Jenkins is started.
-        this.business.init(createScmContext());
     }
 
     public void init() {

--- a/src/test/java/hudson/plugins/scm_sync_configuration/util/ScmSyncConfigurationBaseTest.java
+++ b/src/test/java/hudson/plugins/scm_sync_configuration/util/ScmSyncConfigurationBaseTest.java
@@ -75,12 +75,7 @@ public abstract class ScmSyncConfigurationBaseTest {
         // Instantiating ScmSyncConfigurationPlugin instance for unit tests by using
         // synchronous transactions (instead of an asynchronous ones)
         // => this way, every commit will be processed synchronously !
-        ScmSyncConfigurationPlugin scmSyncConfigPluginInstance = new ScmSyncConfigurationPlugin(true) {
-            @Override
-            public void initialInit() throws Exception {
-                // No-op. We *must not* initialize here in tests because the tests provide their own setup.
-            }
-        };
+        ScmSyncConfigurationPlugin scmSyncConfigPluginInstance = new ScmSyncConfigurationPlugin(true);
 
         // Mocking PluginWrapper attached to current ScmSyncConfigurationPlugin instance
         PluginWrapper pluginWrapper = PowerMockito.mock(PluginWrapper.class);


### PR DESCRIPTION
I have never been able to reproduce this. The only change in 0.0.9 that
matches the stack trace given in the bug report is commit 25db7ec.

Revert commit 25db7ec (undo any early initialization).