### PR TITLE
[JENKINS-66326] Prepare SCM Sync Configuration for core Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,14 +46,14 @@
   <repositories>
     <repository>
         <id>repo.jenkins-ci.org</id>
-        <url>http://repo.jenkins-ci.org/public/</url>
+        <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
         <id>repo.jenkins-ci.org</id>
-        <url>http://repo.jenkins-ci.org/public/</url>
+        <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
   

--- a/src/main/java/hudson/plugins/scm_sync_configuration/utils/Checksums.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/utils/Checksums.java
@@ -1,11 +1,10 @@
 package hudson.plugins.scm_sync_configuration.utils;
 
-import com.google.common.io.ByteStreams;
-import com.google.common.io.Files;
-
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
 import java.util.zip.Checksum;
 
 /**
@@ -13,14 +12,33 @@ import java.util.zip.Checksum;
  * Utility class allowing to provide easy access to jenkins files checksums
  */
 public class Checksums {
+
+    private static final int BUF_SIZE = 0x1000; // 4K
+
     public static boolean fileAndByteArrayContentAreEqual(File file, byte[] content) throws IOException {
         if(!file.exists()){
             return content == null || content.length == 0;
         }
 
+        long fileChecksum;
+        CheckedInputStream in = null;
+        try {
+            in = new CheckedInputStream(new FileInputStream(file), createChecksum());
+            byte[] buffer = new byte[BUF_SIZE];
+            while (in.read(buffer, 0, buffer.length) >= 0) {
+                // keep updating checksum
+            }
+            fileChecksum = in.getChecksum().getValue();
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+        }
+
         Checksum checksum = createChecksum();
-        long fileChecksum = Files.getChecksum(file, checksum);
-        long contentChecksum = ByteStreams.getChecksum(ByteStreams.newInputStreamSupplier(content), checksum);
+        checksum.update(content, 0, content.length);
+        long contentChecksum = checksum.getValue();
+
         return fileChecksum == contentChecksum;
     }
 


### PR DESCRIPTION
Downstream of #70. See [JENKINS-66326](https://issues.jenkins.io/browse/JENKINS-66326) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the following methods which have been removed in the latest version of Guava:

 * `com/google/common/io/ByteStreams#getChecksum`
 * `com/google/common/io/ByteStreams#newInputStreamSupplier`
 * `com/google/common/io/Files#getChecksum`

These methods [existed in Guava 11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/io/ByteStreams.html) but have been [removed in recent versions](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/io/ByteStreams.html).

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. This PR rewrites the relevant code to avoid the use of Guava and use native Java Platform functionality instead.

CC @guipal @rodrigc